### PR TITLE
Set campaign values to empty string

### DIFF
--- a/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.m
+++ b/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.m
@@ -120,9 +120,9 @@
 
 -(void)onConversionDataReceived:(NSDictionary *)installData {
       NSDictionary *campaign = @{
-                @"source": installData[@"media_source"],
-                @"name": installData[@"campaign"],
-                @"adGroup": installData[@"adgroup"]
+                @"source": installData[@"media_source"] ? installData[@"media_source"] : @"",
+                @"name": installData[@"campaign"] ? installData[@"campaign"] : @"",
+                @"adGroup": installData[@"adgroup"] ? installData[@"adgroup"] : @""
       };
 
       NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithDictionary:@{


### PR DESCRIPTION
This prevents a crash due to nil values in the `campaign` dictionary (e.g.: from an organic install).